### PR TITLE
Remove ubuntu 16.04 as platform and bump version for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,6 @@ workflows:
           suite: default-centos-8
           requires: [  danger, delivery ]
       - kitchen/dokken-single:
-          name: default-ubuntu-1604
-          suite: default-ubuntu-1604
-          requires: [  danger, delivery ]
-      - kitchen/dokken-single:
           name: default-ubuntu-1804
           suite: default-ubuntu-1804
           requires: [  danger, delivery ]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,9 +24,6 @@ provisioner:
       port: '5959'
 
 platforms:
-  - name: ubuntu-16.04
-    run_list:
-      - recipe[apt::default]
   - name: ubuntu-18.04
     run_list:
       - recipe[apt::default]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the logstash_lwrp cook
 
 ## Unreleased
 
-## v2.1.0
+## v2.1.0 (2021-01-24)
 
 - Fix for YAML not being loaded by default in newer chef 16 versions
 - Remove Ubuntu 16.04 as a tested platform (EOL in April)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ This file is used to list changes made in each version of the logstash_lwrp cook
 
 ## Unreleased
 
+## v2.1.0
+
 - Fix for YAML not being loaded by default in newer chef 16 versions
+- Remove Ubuntu 16.04 as a tested platform (EOL in April)
 
 ## v2.0.0 (2020-07-21)
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -43,13 +43,6 @@ platforms:
     image: dokken/centos-8
     pid_one_command: /usr/lib/systemd/systemd
 
-- name: ubuntu-16.04
-  run_list:
-    - recipe[apt::default]
-  driver:
-    image: dokken/ubuntu-16.04
-    pid_one_command: /bin/systemd
-
 - name: ubuntu-18.04
   run_list:
     - recipe[apt::default]

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Mihai Petracovici'
 maintainer_email 'petracvv@users.noreply.github.com'
 license 'Apache-2.0'
 description 'Resource-driven Logstash cookbook'
-version '2.0.0'
+version '2.1.0'
 
 issues_url 'https://github.com/petracvv/logstash_lwrp/issues'
 source_url 'https://github.com/petracvv/logstash_lwrp'


### PR DESCRIPTION
This PR removes Ubuntu 16.04 as a tested platform ahead of its EOL in April. I am also bumping the version for an upcoming Supermarket release.